### PR TITLE
feat: add theme toggle

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,6 +37,7 @@
         "framer-motion": "11.15.0",
         "lucide-react": "0.468.0",
         "next": "15.1.3",
+        "next-themes": "^0.2.1",
         "postcss": "^8.4.31",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -15468,6 +15469,17 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
+      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -16413,7 +16425,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "framer-motion": "11.15.0",
     "lucide-react": "0.468.0",
     "next": "15.1.3",
+    "next-themes": "^0.2.1",
     "postcss": "^8.4.31",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { AuthInitializer } from "@/components/auth/AuthInitializer"
 import { AuthenticatedAssistantAgent } from "@/components/help/AuthenticatedAssistantAgent"
+import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
 import "@/styles/globals.css"
 import type { Metadata } from "next"
@@ -20,12 +21,14 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        <div className="min-h-screen bg-background font-sans antialiased">
-          <AuthInitializer />
-          {children}
-          <AuthenticatedAssistantAgent />
-          <Toaster />
-        </div>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
+          <div className="min-h-screen bg-background font-sans antialiased">
+            <AuthInitializer />
+            {children}
+            <AuthenticatedAssistantAgent />
+            <Toaster />
+          </div>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
+import { ThemeToggle } from "./ThemeToggle"
 import { useToast } from "@/hooks/use-toast"
 import { useAuthStore } from "@/stores/auth"
 import Link from "next/link"
@@ -42,13 +43,13 @@ export function Navigation({ className }: NavigationProps) {
   }
 
   return (
-    <nav className={`bg-white shadow ${className}`}>
+    <nav className={`bg-background shadow ${className}`}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-6">
           {/* Logo and Brand */}
           <div className="flex items-center">
             <Link href="/dashboard" className="flex items-center">
-              <h1 className="text-2xl font-bold text-gray-900">RealtorAgentAI</h1>
+              <h1 className="text-2xl font-bold text-foreground">RealtorAgentAI</h1>
             </Link>
           </div>
 
@@ -58,7 +59,7 @@ export function Navigation({ className }: NavigationProps) {
               <Link
                 key={item.href}
                 href={item.href}
-                className="text-gray-700 hover:text-gray-900 px-3 py-2 rounded-md text-sm font-medium transition-colors"
+                className="text-muted-foreground hover:text-foreground px-3 py-2 rounded-md text-sm font-medium transition-colors"
               >
                 {item.label}
               </Link>
@@ -67,12 +68,13 @@ export function Navigation({ className }: NavigationProps) {
 
           {/* User Menu */}
           <div className="flex items-center space-x-4">
-            <span className="text-sm text-gray-700">
+            <span className="text-sm text-muted-foreground">
               Welcome, {user.name}
             </span>
-            <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
+            <span className="text-xs text-muted-foreground bg-accent px-2 py-1 rounded">
               {user.role}
             </span>
+            <ThemeToggle />
             <Button onClick={handleLogout} variant="outline" size="sm">
               Logout
             </Button>
@@ -87,7 +89,7 @@ export function Navigation({ className }: NavigationProps) {
             <Link
               key={item.href}
               href={item.href}
-              className="text-gray-700 hover:text-gray-900 block px-3 py-2 rounded-md text-base font-medium"
+              className="text-muted-foreground hover:text-foreground block px-3 py-2 rounded-md text-base font-medium"
             >
               {item.label}
             </Link>

--- a/frontend/src/components/layout/ThemeToggle.tsx
+++ b/frontend/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Moon, Sun } from "lucide-react"
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
+  if (!mounted) return null
+
+  const toggleTheme = () => setTheme(theme === "dark" ? "light" : "dark")
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme}>
+      <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  )
+}

--- a/frontend/src/components/theme-provider.tsx
+++ b/frontend/src/components/theme-provider.tsx
@@ -1,0 +1,9 @@
+"use client"
+
+import * as React from "react"
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+import { type ThemeProviderProps } from "next-themes/dist/types"
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}


### PR DESCRIPTION
## Summary
- integrate next-themes and ThemeProvider in app layout
- add ThemeToggle button to header navigation
- update navigation styling for theme variables

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint` *(prompts for configuration and exits)*
- `pre-commit run --files frontend/package.json frontend/package-lock.json frontend/src/app/layout.tsx frontend/src/components/layout/Navigation.tsx frontend/src/components/layout/ThemeToggle.tsx frontend/src/components/theme-provider.tsx` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*


------
https://chatgpt.com/codex/tasks/task_e_688fc1fdfdac832cb1ae790e4fe361a0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added theme switching functionality, allowing users to toggle between light and dark modes.
  * Introduced a theme toggle button in the navigation menu for easy access.
* **Style**
  * Updated navigation bar and text styles to be theme-aware, ensuring consistent appearance across light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->