### PR TITLE
feat(frontend): add motion animations

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,17 @@
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
+import { motion } from "framer-motion"
+
+const MotionButton = motion(Button)
 
 export default function HomePage() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center p-24">
+    <motion.div
+      className="flex min-h-screen flex-col items-center justify-center p-24"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.5 }}
+    >
       <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm">
         <h1 className="text-4xl font-bold text-center mb-8">
           RealtorAgentAI
@@ -14,9 +22,9 @@ export default function HomePage() {
 
         <div className="flex justify-center mb-12">
           <Link href="/login">
-            <Button size="lg">
+            <MotionButton size="lg" whileHover={{ scale: 1.05 }}>
               Get Started
-            </Button>
+            </MotionButton>
           </Link>
         </div>
 
@@ -41,6 +49,6 @@ export default function HomePage() {
           </div>
         </div>
       </div>
-    </div>
+    </motion.div>
   )
 }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -54,6 +54,6 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-gradient-to-br from-slate-50 to-slate-100 text-foreground;
   }
 }


### PR DESCRIPTION
## Summary
- add subtle fade-in animation to homepage container
- scale "Get Started" button on hover using framer-motion
- apply gradient background across the app

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint` *(fails: Interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689048c06030832cbb3ace0384a7e4c5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smooth fade-in animation to the homepage content.
  * Introduced a scale-up animation effect on the "Get Started" button when hovered.

* **Style**
  * Updated the background of the homepage to a subtle gradient for a more modern look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->