### PR TITLE
feat: add theme toggle

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,6 +37,7 @@
         "framer-motion": "11.15.0",
         "lucide-react": "0.468.0",
         "next": "15.1.3",
+        "next-themes": "^0.4.6",
         "postcss": "^8.4.31",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -15468,6 +15469,16 @@
         }
       }
     },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -16413,7 +16424,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,6 +56,7 @@
     "framer-motion": "11.15.0",
     "lucide-react": "0.468.0",
     "next": "15.1.3",
+    "next-themes": "^0.4.6",
     "postcss": "^8.4.31",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { AuthInitializer } from "@/components/auth/AuthInitializer"
 import { AuthenticatedAssistantAgent } from "@/components/help/AuthenticatedAssistantAgent"
 import { Toaster } from "@/components/ui/toaster"
 import "@/styles/globals.css"
+import { ThemeProvider } from "next-themes"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 
@@ -20,12 +21,14 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
-        <div className="min-h-screen bg-background font-sans antialiased">
-          <AuthInitializer />
-          {children}
-          <AuthenticatedAssistantAgent />
-          <Toaster />
-        </div>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <div className="min-h-screen bg-background font-sans antialiased">
+            <AuthInitializer />
+            {children}
+            <AuthenticatedAssistantAgent />
+            <Toaster />
+          </div>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
+import { ThemeToggle } from "@/components/ui/theme-toggle"
 import { useToast } from "@/hooks/use-toast"
 import { useAuthStore } from "@/stores/auth"
 import Link from "next/link"
@@ -70,12 +71,13 @@ export function Navigation({ className }: NavigationProps) {
             <span className="text-sm text-gray-700">
               Welcome, {user.name}
             </span>
-            <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
-              {user.role}
-            </span>
-            <Button onClick={handleLogout} variant="outline" size="sm">
-              Logout
-            </Button>
+          <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
+            {user.role}
+          </span>
+          <ThemeToggle />
+          <Button onClick={handleLogout} variant="outline" size="sm">
+            Logout
+          </Button>
           </div>
         </div>
       </div>

--- a/frontend/src/components/ui/theme-toggle.tsx
+++ b/frontend/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Moon, Sun } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+
+  const toggleTheme = () => {
+    setTheme(theme === "light" ? "dark" : "light")
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+    >
+      <Sun className="size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- install `next-themes` and wrap app with `ThemeProvider`
- add reusable `ThemeToggle` component
- integrate theme toggle into navigation bar

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689048ccee2c832cbcab6b321a60b961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a theme toggle button to the navigation bar, allowing users to switch between light and dark modes.
  * The application now supports system theme preferences and will automatically adapt to your device's theme settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->