### PR TITLE
feat: add sticky translucent nav bar

### DIFF
--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -42,7 +42,9 @@ export function Navigation({ className }: NavigationProps) {
   }
 
   return (
-    <nav className={`bg-white shadow ${className}`}>
+    <nav
+      className={`sticky top-0 z-50 backdrop-blur bg-white/70 supports-backdrop-blur:bg-white/60 shadow ${className}`}
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-6">
           {/* Logo and Brand */}
@@ -81,7 +83,7 @@ export function Navigation({ className }: NavigationProps) {
       </div>
 
       {/* Mobile Navigation */}
-      <div className="md:hidden">
+      <div className="md:hidden sticky top-0 z-50 backdrop-blur bg-white/70 supports-backdrop-blur:bg-white/60 shadow">
         <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3 border-t">
           {navigationItems.map((item) => (
             <Link


### PR DESCRIPTION
## Summary
- make navigation bar sticky and translucent with backdrop blur
- apply same style to mobile nav wrapper and elevate with z-index

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run type-check` *(fails: TS2322 and other type errors)*
- `pre-commit run --files frontend/src/components/layout/Navigation.tsx` *(fails: RuntimeError: failed to find interpreter for python3.11)*

------
https://chatgpt.com/codex/tasks/task_e_689048df4530832cabafe41c61cdb1d9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the navigation bar and mobile menu to remain sticky at the top of the page with enhanced backdrop blur and semi-transparent background effects for improved visual appeal and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->