### PR TITLE
feat: add command palette

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "axios": "1.7.9",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
+        "cmdk": "^1.1.1",
         "date-fns": "4.1.0",
         "framer-motion": "11.15.0",
         "lucide-react": "0.468.0",
@@ -9041,6 +9042,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -16413,7 +16430,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
     "axios": "1.7.9",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "cmdk": "^1.1.1",
     "date-fns": "4.1.0",
     "framer-motion": "11.15.0",
     "lucide-react": "0.468.0",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { AuthInitializer } from "@/components/auth/AuthInitializer"
 import { AuthenticatedAssistantAgent } from "@/components/help/AuthenticatedAssistantAgent"
 import { Toaster } from "@/components/ui/toaster"
+import { CommandPalette } from "@/components/ui/command-palette"
 import "@/styles/globals.css"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
@@ -25,6 +26,7 @@ export default function RootLayout({
           {children}
           <AuthenticatedAssistantAgent />
           <Toaster />
+          <CommandPalette />
         </div>
       </body>
     </html>

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -6,6 +6,27 @@ import { useAuthStore } from "@/stores/auth"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 
+export interface NavigationItem {
+  href: string
+  label: string
+}
+
+export const getNavigationItems = (user?: { role: string } | null): NavigationItem[] => {
+  const items: NavigationItem[] = [
+    { href: "/dashboard", label: "Dashboard" },
+    { href: "/documents", label: "Documents" },
+    { href: "/contracts", label: "Contracts" },
+    { href: "/review", label: "Review" },
+    { href: "/signatures", label: "Signatures" },
+  ]
+
+  if (user?.role === "admin") {
+    items.push({ href: "/admin", label: "Admin" })
+  }
+
+  return items
+}
+
 interface NavigationProps {
   className?: string
 }
@@ -28,18 +49,7 @@ export function Navigation({ className }: NavigationProps) {
     return null
   }
 
-  const navigationItems = [
-    { href: "/dashboard", label: "Dashboard" },
-    { href: "/documents", label: "Documents" },
-    { href: "/contracts", label: "Contracts" },
-    { href: "/review", label: "Review" },
-    { href: "/signatures", label: "Signatures" },
-  ]
-
-  // Add admin-only items
-  if (user.role === 'admin') {
-    navigationItems.push({ href: "/admin", label: "Admin" })
-  }
+  const navigationItems = getNavigationItems(user)
 
   return (
     <nav className={`bg-white shadow ${className}`}>

--- a/frontend/src/components/ui/command-palette.tsx
+++ b/frontend/src/components/ui/command-palette.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import { Command } from "cmdk"
+import { useRouter } from "next/navigation"
+import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { getNavigationItems } from "@/components/layout/Navigation"
+import { useAuthStore } from "@/stores/auth"
+
+export function CommandPalette() {
+  const router = useRouter()
+  const { user } = useAuthStore()
+  const [open, setOpen] = React.useState(false)
+
+  React.useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        setOpen((o) => !o)
+      }
+    }
+    document.addEventListener("keydown", down)
+    return () => document.removeEventListener("keydown", down)
+  }, [])
+
+  const items = getNavigationItems(user)
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="p-0 overflow-hidden">
+        <Command label="Command Palette">
+          <Command.Input
+            placeholder="Type a command or search..."
+            className="h-11 w-full border-b px-4 outline-none"
+          />
+          <Command.List>
+            <Command.Empty className="p-4 text-sm">No results found.</Command.Empty>
+            <Command.Group heading="Navigation">
+              {items.map((item) => (
+                <Command.Item
+                  key={item.href}
+                  onSelect={() => {
+                    setOpen(false)
+                    router.push(item.href)
+                  }}
+                  className="cursor-pointer px-4 py-2 text-sm"
+                >
+                  {item.label}
+                </Command.Item>
+              ))}
+            </Command.Group>
+          </Command.List>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- add `cmdk` library and command palette UI
- share navigation items between command palette and nav bar
- wire command palette into root layout with keyboard shortcut

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run type-check` *(fails: multiple TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_689049284134832cab8fdeb161fbb7cb