### PR TITLE
feat: integrate inter font and typography

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,9 +3,9 @@ import { AuthenticatedAssistantAgent } from "@/components/help/AuthenticatedAssi
 import { Toaster } from "@/components/ui/toaster"
 import "@/styles/globals.css"
 import type { Metadata } from "next"
-import { Inter } from "next/font/google"
+import { Inter } from "@next/font/google"
 
-const inter = Inter({ subsets: ["latin"] })
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })
 
 export const metadata: Metadata = {
   title: "RealtorAgentAI - Real Estate Contract Platform",
@@ -18,9 +18,9 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
-        <div className="min-h-screen bg-background font-sans antialiased">
+    <html lang="en" className={inter.variable} suppressHydrationWarning>
+      <body className="font-sans antialiased">
+        <div className="min-h-screen bg-background">
           <AuthInitializer />
           {children}
           <AuthenticatedAssistantAgent />

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,11 +4,9 @@ import Link from "next/link"
 export default function HomePage() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center p-24">
-      <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm">
-        <h1 className="text-4xl font-bold text-center mb-8">
-          RealtorAgentAI
-        </h1>
-        <p className="text-xl text-center text-muted-foreground mb-8">
+      <div className="z-10 max-w-5xl w-full items-center justify-between text-sm">
+        <h1 className="text-center mb-8">RealtorAgentAI</h1>
+        <p className="text-center text-muted-foreground mb-8">
           Multi-Agent Real Estate Contract Platform
         </p>
 
@@ -22,19 +20,19 @@ export default function HomePage() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-12">
           <div className="p-6 border rounded-lg">
-            <h2 className="text-lg font-semibold mb-2">Document Intake</h2>
+            <h3 className="text-lg font-semibold mb-2">Document Intake</h3>
             <p className="text-sm text-muted-foreground">
               Upload and process real estate documents with AI-powered extraction
             </p>
           </div>
           <div className="p-6 border rounded-lg">
-            <h2 className="text-lg font-semibold mb-2">Contract Generator</h2>
+            <h3 className="text-lg font-semibold mb-2">Contract Generator</h3>
             <p className="text-sm text-muted-foreground">
               Generate standardized contracts from templates and extracted data
             </p>
           </div>
           <div className="p-6 border rounded-lg">
-            <h2 className="text-lg font-semibold mb-2">Signature Tracking</h2>
+            <h3 className="text-lg font-semibold mb-2">Signature Tracking</h3>
             <p className="text-sm text-muted-foreground">
               Track multi-party signatures with audit trails and notifications
             </p>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -56,4 +56,16 @@
   body {
     @apply bg-background text-foreground;
   }
+  h1 {
+    @apply text-4xl font-bold tracking-tight;
+  }
+  h2 {
+    @apply text-3xl font-semibold tracking-tight;
+  }
+  h3 {
+    @apply text-2xl font-semibold tracking-tight;
+  }
+  p {
+    @apply text-lg leading-relaxed;
+  }
 }

--- a/frontend/src/types/next-font.d.ts
+++ b/frontend/src/types/next-font.d.ts
@@ -1,0 +1,3 @@
+declare module "@next/font/google" {
+  export { Inter } from "next/font/google"
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+const { fontFamily } = require("tailwindcss/defaultTheme")
+
 module.exports = {
   darkMode: ["class"],
   content: [
@@ -17,6 +19,20 @@ module.exports = {
       },
     },
     extend: {
+      fontFamily: {
+        sans: ["var(--font-inter)", ...fontFamily.sans],
+      },
+      fontWeight: {
+        100: "100",
+        200: "200",
+        300: "300",
+        400: "400",
+        500: "500",
+        600: "600",
+        700: "700",
+        800: "800",
+        900: "900",
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Summary
- switch to Inter variable font via `@next/font/google` and apply globally
- extend Tailwind with font family, numeric weights, and typographic base scale
- clean up homepage typography and add module declaration for fonts

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run type-check` *(fails: TS2345, TS2322, TS2339, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689049465258832cbaf538224c67926f