### PR TITLE
feat: add agent websocket transport

### DIFF
--- a/backend/app/agent_runtime.py
+++ b/backend/app/agent_runtime.py
@@ -1,0 +1,12 @@
+"""Simplified agent runtime used for WebSocket streaming tests."""
+from typing import AsyncGenerator, Dict, Any
+import asyncio
+
+async def run_agent(params: Dict[str, Any]) -> AsyncGenerator[Dict[str, Any], None]:
+    """Simulate running an agent by streaming token events."""
+    prompt: str = params.get("prompt", "")
+    words = prompt.split()
+    for word in words:
+        await asyncio.sleep(0)  # allow context switch
+        yield {"type": "token", "text": word + " "}
+    yield {"type": "status", "phase": "done"}

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,34 @@
+"""Authentication helpers for WebSocket connections."""
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from jose import JWTError, jwt
+
+import os
+
+JWT_SECRET = os.getenv("JWT_SECRET_KEY", "dev-secret-key-change-in-production")
+JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
+
+
+def decode_jwt(token: str) -> Dict[str, Any]:
+    """Decode and validate a JWT token.
+
+    Raises ``ValueError`` if the token is invalid.
+    """
+    try:
+        payload = jwt.decode(
+            token,
+            JWT_SECRET,
+            algorithms=[JWT_ALGORITHM],
+            options={"verify_aud": False},
+        )
+        now = datetime.now(timezone.utc)
+        if "nbf" in payload and datetime.fromtimestamp(payload["nbf"], timezone.utc) > now:
+            raise JWTError("Token not yet valid")
+        if "iat" in payload and datetime.fromtimestamp(payload["iat"], timezone.utc) > now:
+            raise JWTError("Token issued in the future")
+        return payload
+    except JWTError as exc:
+        raise ValueError("Invalid token") from exc
+
+__all__ = ["decode_jwt"]

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -8,6 +8,8 @@ import os
 
 JWT_SECRET = os.getenv("JWT_SECRET_KEY", "dev-secret-key-change-in-production")
 JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
+JWT_ISSUER = os.getenv("JWT_ISSUER", "realtoragentai")
+JWT_AUDIENCE = os.getenv("JWT_AUDIENCE", "realtoragentai")
 
 
 def decode_jwt(token: str) -> Dict[str, Any]:
@@ -20,7 +22,8 @@ def decode_jwt(token: str) -> Dict[str, Any]:
             token,
             JWT_SECRET,
             algorithms=[JWT_ALGORITHM],
-            options={"verify_aud": False},
+            audience=JWT_AUDIENCE,
+            issuer=JWT_ISSUER,
         )
         now = datetime.now(timezone.utc)
         if "nbf" in payload and datetime.fromtimestamp(payload["nbf"], timezone.utc) > now:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,13 @@
+"""Configuration constants for WebSocket sessions."""
+
+class WSSettings:
+    MAX_WS_MSG_BYTES = 256 * 1024
+    HEARTBEAT_INTERVAL = 25
+    IDLE_TIMEOUT_SECONDS = 120
+    ACK_WINDOW = 100
+    RATE_LIMIT_MSGS = 20
+    RATE_LIMIT_INTERVAL = 10
+
+ws_settings = WSSettings()
+
+__all__ = ["ws_settings"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,7 @@ from .core.security import (
 # Import routers
 from .api import auth, files, contracts, templates, signatures, webhooks, admin, tasks, model_router, agent_orchestrator
 from .api.v1 import ai_agents, ai_agents_ws, advanced_agents, performance, analytics
+from . import ws
 
 # Setup logging
 setup_logging()
@@ -365,6 +366,7 @@ app.include_router(ai_agents_ws.ws_router, prefix="/api/v1", tags=["ai-agents-we
 app.include_router(advanced_agents.router, prefix="/api/v1", tags=["advanced-ai-agents"])
 app.include_router(performance.router, prefix="/api/v1", tags=["performance-optimization"])
 app.include_router(analytics.router, prefix="/api/v1", tags=["analytics"])
+app.include_router(ws.router)
 
 
 if __name__ == "__main__":

--- a/backend/app/ws.py
+++ b/backend/app/ws.py
@@ -1,0 +1,223 @@
+"""WebSocket endpoint for real-time agent sessions."""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import uuid
+from collections import deque
+from typing import Any, Deque, Dict, Optional
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from .auth import decode_jwt
+from .agent_runtime import run_agent
+from .config import ws_settings
+
+router = APIRouter()
+
+
+class Session:
+    """Holds buffered events for a session."""
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        self.seq = 0
+        self.buffer: Deque[Dict[str, Any]] = deque(maxlen=1000)
+        self.agent_task: Optional[asyncio.Task] = None
+
+
+sessions: Dict[str, Session] = {}
+
+
+class Connection:
+    def __init__(self, websocket: WebSocket):
+        self.ws = websocket
+        self.send_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        self.last_ack = 0
+        self.last_recv = time.time()
+        self.rate_timestamps: Deque[float] = deque()
+        self.session: Optional[Session] = None
+
+
+async def websocket_handler(websocket: WebSocket):
+    token = websocket.headers.get("sec-websocket-protocol") or websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=4401)
+        return
+    try:
+        decode_jwt(token)
+    except ValueError:
+        await websocket.close(code=4401)
+        return
+
+    await websocket.accept(subprotocol=token)
+
+    conn = Connection(websocket)
+
+    writer_task = asyncio.create_task(writer(conn))
+    heartbeat_task = asyncio.create_task(heartbeat(conn))
+
+    try:
+        await reader(conn)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        writer_task.cancel()
+        heartbeat_task.cancel()
+        if conn.session and conn.session.agent_task:
+            conn.session.agent_task.cancel()
+
+
+@router.websocket("/ws/agent")
+async def ws_endpoint(websocket: WebSocket):
+    await websocket_handler(websocket)
+
+
+async def reader(conn: Connection):
+    ws = conn.ws
+    while True:
+        message = await ws.receive()
+        conn.last_recv = time.time()
+
+        if message["type"] == "websocket.disconnect":
+            raise WebSocketDisconnect
+
+        data = message.get("text")
+        if data is None:
+            continue
+
+        if len(data.encode("utf-8")) > ws_settings.MAX_WS_MSG_BYTES:
+            await conn.send_queue.put({
+                "jsonrpc": "2.0",
+                "error": {"code": 4009, "message": "Message too large"},
+            })
+            continue
+
+        now = time.time()
+        conn.rate_timestamps.append(now)
+        while conn.rate_timestamps and now - conn.rate_timestamps[0] > ws_settings.RATE_LIMIT_INTERVAL:
+            conn.rate_timestamps.popleft()
+        if len(conn.rate_timestamps) > ws_settings.RATE_LIMIT_MSGS:
+            await conn.send_queue.put({
+                "jsonrpc": "2.0",
+                "error": {"code": 429, "message": "Rate limit exceeded"},
+            })
+            continue
+
+        try:
+            msg = json.loads(data)
+        except json.JSONDecodeError:
+            await conn.send_queue.put({
+                "jsonrpc": "2.0",
+                "error": {"code": -32700, "message": "Invalid JSON"},
+            })
+            continue
+
+        method = msg.get("method")
+        msg_id = msg.get("id")
+        params = msg.get("params", {})
+
+        if method == "ack":
+            conn.last_ack = max(conn.last_ack, params.get("lastSeq", 0))
+            continue
+
+        if method == "agent.run":
+            await handle_run(conn, msg_id, params)
+        elif method == "agent.cancel":
+            await handle_cancel(conn, msg_id, params)
+        elif method == "session.resume":
+            await handle_resume(conn, msg_id, params)
+        else:
+            await conn.send_queue.put({
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {"code": -32601, "message": "Unknown method"},
+            })
+
+
+async def writer(conn: Connection):
+    ws = conn.ws
+    while True:
+        msg = await conn.send_queue.get()
+        event = msg.get("event")
+        if event and conn.session and "seq" in event:
+            while event["seq"] - conn.last_ack > ws_settings.ACK_WINDOW:
+                await asyncio.sleep(0.1)
+        await ws.send_text(json.dumps(msg))
+
+
+async def heartbeat(conn: Connection):
+    ws = conn.ws
+    missed = 0
+    while True:
+        await asyncio.sleep(ws_settings.HEARTBEAT_INTERVAL)
+        await conn.send_queue.put({
+            "jsonrpc": "2.0",
+            "event": {"type": "heartbeat", "ts": time.time()},
+        })
+        if time.time() - conn.last_recv > ws_settings.HEARTBEAT_INTERVAL * 2:
+            missed += 1
+        else:
+            missed = 0
+        if time.time() - conn.last_recv > ws_settings.IDLE_TIMEOUT_SECONDS or missed >= 2:
+            await ws.close()
+            break
+
+
+async def handle_run(conn: Connection, msg_id: Optional[str], params: Dict[str, Any]):
+    session_id = params.get("sessionId") or str(uuid.uuid4())
+    session = sessions.get(session_id)
+    if session is None:
+        session = Session(session_id)
+        sessions[session_id] = session
+    conn.session = session
+
+    await conn.send_queue.put({
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "result": {"status": "started", "sessionId": session_id},
+    })
+
+    async def run():
+        async for ev in run_agent(params):
+            session.seq += 1
+            ev["seq"] = session.seq
+            session.buffer.append(ev)
+            await conn.send_queue.put({"jsonrpc": "2.0", "event": ev})
+        await conn.send_queue.put({"jsonrpc": "2.0", "id": msg_id, "result": {"status": "done"}})
+
+    session.agent_task = asyncio.create_task(run())
+
+
+async def handle_cancel(conn: Connection, msg_id: Optional[str], params: Dict[str, Any]):
+    if conn.session and conn.session.agent_task:
+        conn.session.agent_task.cancel()
+        await conn.send_queue.put({
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {"status": "cancelled"},
+        })
+
+
+async def handle_resume(conn: Connection, msg_id: Optional[str], params: Dict[str, Any]):
+    session_id = params.get("sessionId")
+    last_seq = params.get("lastSeq", 0)
+    session = sessions.get(session_id)
+    if not session:
+        await conn.send_queue.put({
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "error": {"code": 404, "message": "session not found"},
+        })
+        return
+    conn.session = session
+    conn.last_ack = last_seq
+    for ev in list(session.buffer):
+        if ev.get("seq", 0) > last_seq:
+            await conn.send_queue.put({"jsonrpc": "2.0", "event": ev})
+    await conn.send_queue.put({
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "result": {"status": "resumed", "sessionId": session_id},
+    })

--- a/backend/tests/test_ws.py
+++ b/backend/tests/test_ws.py
@@ -1,0 +1,98 @@
+import json
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+from fastapi.websockets import WebSocketDisconnect
+
+from fastapi import FastAPI
+from jose import jwt
+
+from app.ws import router as ws_router
+from app import config as ws_config
+
+
+@pytest.fixture
+def app():
+    app = FastAPI()
+    app.include_router(ws_router)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+SECRET = "dev-secret-key-change-in-production"
+ALG = "HS256"
+
+
+def make_token() -> str:
+    return jwt.encode({"sub": "tester"}, SECRET, algorithm=ALG)
+
+
+def test_invalid_token(client):
+    try:
+        with client.websocket_connect("/ws/agent?token=bad") as ws:
+            with pytest.raises(WebSocketDisconnect):
+                ws.receive_text()
+    except WebSocketDisconnect as exc:
+        assert exc.code == 4401
+    else:
+        pytest.fail("Expected WebSocketDisconnect")
+
+
+def test_agent_run_stream(client):
+    token = make_token()
+    with client.websocket_connect(f"/ws/agent?token={token}") as ws:
+        ws.send_text(json.dumps({
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": "agent.run",
+            "params": {"prompt": "hello world"},
+        }))
+        start = ws.receive_json()
+        assert start["result"]["status"] == "started"
+        tokens = []
+        while True:
+            msg = ws.receive_json()
+            if msg.get("event", {}).get("type") == "token":
+                tokens.append(msg["event"]["text"])
+            elif msg.get("result", {}).get("status") == "done":
+                break
+        assert "hello" in "".join(tokens)
+
+
+def test_oversized_message(client):
+    token = make_token()
+    big = "a" * (ws_config.ws_settings.MAX_WS_MSG_BYTES + 10)
+    with client.websocket_connect(f"/ws/agent?token={token}") as ws:
+        ws.send_text(big)
+        msg = ws.receive_json()
+        assert msg["error"]["code"] == 4009
+
+
+def test_rate_limit(client):
+    token = make_token()
+    with client.websocket_connect(f"/ws/agent?token={token}") as ws:
+        for i in range(ws_config.ws_settings.RATE_LIMIT_MSGS + 1):
+            ws.send_text(json.dumps({
+                "jsonrpc": "2.0",
+                "id": str(i),
+                "method": "ack",
+                "params": {"lastSeq": 0},
+            }))
+        msg = ws.receive_json()
+        assert msg["error"]["code"] == 429
+
+
+def test_heartbeat_idle_timeout(client, monkeypatch):
+    ws_config.ws_settings.HEARTBEAT_INTERVAL = 0.1
+    ws_config.ws_settings.IDLE_TIMEOUT_SECONDS = 0.2
+    token = make_token()
+    with client.websocket_connect(f"/ws/agent?token={token}") as ws:
+        time.sleep(1.0)
+        with pytest.raises(WebSocketDisconnect):
+            while True:
+                ws.receive_text()

--- a/docs/agent-ws.md
+++ b/docs/agent-ws.md
@@ -1,0 +1,35 @@
+# Agent WebSocket API
+
+Connect to `/ws/agent` using a JWT access token supplied as the WebSocket subprotocol or `?token` query parameter.
+
+## Client Methods
+
+```json
+{ "jsonrpc": "2.0", "id": "1", "method": "agent.run", "params": { "prompt": "hi" } }
+```
+
+- `agent.run {prompt, sessionId?, options?}` – start an agent session. Server replies `{result:{status:"started",sessionId}}` then streams events.
+- `agent.cancel {jobId}` – cancel running job.
+- `session.resume {sessionId,lastSeq}` – replay buffered events after reconnect.
+- `ack {lastSeq}` – acknowledge streaming events for backpressure.
+
+## Server Events
+
+Each message uses the envelope:
+
+```json
+{ "jsonrpc": "2.0", "event": { "type": "token", "seq": 1, "text": "Hello" } }
+```
+
+Types: `token`, `status`, `tool_call`, `tool_result`, `cost_update`, `stderr`, `warning`, `heartbeat`.
+
+## Limits
+
+- Max message size: 256&nbsp;KB
+- Rate limit: 20 messages / 10&nbsp;s
+- Heartbeat every ~25&nbsp;s; idle connections close after 2 missed heartbeats or 120&nbsp;s of silence
+- Ack window: 100 sequences
+
+## Reconnect & Resume
+
+Store the returned `sessionId` and latest `seq`. On reconnect send `session.resume` with these values to resume without duplicate tokens.

--- a/frontend/src/components/AgentConsole.tsx
+++ b/frontend/src/components/AgentConsole.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { useAgentSession } from '../hooks/useAgentSession';
+
+export default function AgentConsole({ token }: { token: string | null }) {
+  const [prompt, setPrompt] = useState('');
+  const { connected, output, run, status } = useAgentSession(token);
+
+  return (
+    <div className="p-2">
+      <textarea
+        className="w-full border p-2"
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+      />
+      <button
+        onClick={() => run(prompt)}
+        disabled={!connected}
+        className="bg-blue-500 text-white px-2 py-1 mt-2"
+      >
+        Run
+      </button>
+      <div className="mt-2 whitespace-pre-wrap border p-2 min-h-[4rem]">
+        {output}
+      </div>
+      <div className="text-sm text-gray-500">Status: {status}</div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useAgentSession.ts
+++ b/frontend/src/hooks/useAgentSession.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef, useState } from 'react';
+import { connectAgentWS } from '../lib/wsClient';
+
+const ACK_INTERVAL = 50;
+
+export function useAgentSession(token: string | null) {
+  const wsRef = useRef<WebSocket | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [lastSeq, setLastSeq] = useState(0);
+  const [output, setOutput] = useState('');
+  const [status, setStatus] = useState('');
+
+  const send = (msg: any) => {
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(msg));
+    }
+  };
+
+  const connect = () => {
+    if (!token) return;
+    const ws = connectAgentWS(token);
+    ws.onopen = () => {
+      setConnected(true);
+      if (sessionId) {
+        send({ jsonrpc: '2.0', id: 'resume', method: 'session.resume', params: { sessionId, lastSeq } });
+      }
+    };
+    ws.onclose = () => {
+      setConnected(false);
+      wsRef.current = null;
+      // attempt single reconnect
+      if (sessionId) {
+        setTimeout(connect, 500);
+      }
+    };
+    ws.onmessage = (ev) => {
+      try {
+        const msg = JSON.parse(ev.data);
+        if (msg.result?.sessionId) {
+          setSessionId(msg.result.sessionId);
+        }
+        if (msg.event) {
+          const evn = msg.event;
+          if (typeof evn.seq === 'number') {
+            setLastSeq(evn.seq);
+            if (evn.seq % ACK_INTERVAL === 0) {
+              send({ jsonrpc: '2.0', method: 'ack', params: { lastSeq: evn.seq } });
+            }
+          }
+          if (evn.type === 'token' && evn.text) {
+            setOutput((o) => o + evn.text);
+          }
+          if (evn.type === 'status' && evn.phase) {
+            setStatus(evn.phase);
+          }
+        }
+      } catch (err) {
+        // ignore
+      }
+    };
+    wsRef.current = ws;
+  };
+
+  useEffect(() => {
+    connect();
+    return () => wsRef.current?.close();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  const run = (prompt: string) => {
+    setOutput('');
+    send({ jsonrpc: '2.0', id: 'run', method: 'agent.run', params: { prompt, sessionId } });
+  };
+
+  const cancel = (jobId: string) => {
+    send({ jsonrpc: '2.0', id: 'cancel', method: 'agent.cancel', params: { jobId } });
+  };
+
+  return { connected, sessionId, lastSeq, run, cancel, output, status };
+}

--- a/frontend/src/lib/wsClient.ts
+++ b/frontend/src/lib/wsClient.ts
@@ -1,0 +1,5 @@
+export function connectAgentWS(token: string): WebSocket {
+  const origin = typeof window !== 'undefined' ? window.location.origin : '';
+  const url = origin.replace(/^http/, 'ws') + '/ws/agent';
+  return new WebSocket(url, token);
+}


### PR DESCRIPTION
## Summary
- add `/ws/agent` WebSocket with JWT auth, heartbeats, backpressure and resume support
- basic React hook and console component for streaming agent output
- document WebSocket protocol and add regression tests

## Testing
- `pytest tests/test_ws.py -q`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4b8860bc832ca1e71f7038b59ddd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Real-time agent streaming over WebSocket with JWT-based authentication, session start/cancel/resume, acknowledgements, and client-side reconnect/resume support.
  - Frontend: agent console component, connection hook, and WebSocket helper to run prompts and display streaming output/status.
  - Server: configurable WebSocket session limits, heartbeat, rate limiting, and idle handling.

- **Documentation**
  - Added guide for the Agent WebSocket API (connection, RPCs, events, limits, resume workflow).

- **Tests**
  - End-to-end WebSocket tests covering auth, streaming, oversized messages, rate limiting, and heartbeat/idle timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->